### PR TITLE
Support ruby 1.8.7 again

### DIFF
--- a/lib/puppet-lint/plugins/check_strict_indent.rb
+++ b/lib/puppet-lint/plugins/check_strict_indent.rb
@@ -150,7 +150,7 @@ PuppetLint.new_check(:'strict_indent') do
     else
       tokens.insert(
         tokens.find_index(problem[:token]) + 1,
-        PuppetLint::Lexer::Token.new(:INDENT, char_for_indent * problem[:indent], problem[:line], problem[:column]),
+        PuppetLint::Lexer::Token.new(:INDENT, char_for_indent * problem[:indent], problem[:line], problem[:column])
       )
     end
   end


### PR DESCRIPTION
Hi,

without this fix I get this error.
```
bundle exec rake all
rake aborted!
SyntaxError: /usr/local/rvm/gems/ruby-1.8.7-p374/gems/puppet-lint-strict_indent-check-2.0.2/lib/puppet-lint/plugins/check_strict_indent.rb:154: syntax error, unexpected ')'
/usr/local/rvm/gems/ruby-1.8.7-p374/gems/puppet-lint-2.0.0/lib/puppet-lint/plugins.rb:18:in `load'
```

I think it's a small fix to work with old ruby versions. I know 1.8.7 is EndOfLife, but some old supported Distros has ruby 1.8.7 as default ruby.

Thanks in advance.

If you accept this change, please don't forget to push this new version to rubygems.

Greetings
Reamer