### PR TITLE
Reset not only whitespaces but comments too.

### DIFF
--- a/lib/puppet-lint/plugins/check_strict_indent.rb
+++ b/lib/puppet-lint/plugins/check_strict_indent.rb
@@ -57,7 +57,7 @@ PuppetLint.new_check(:'strict_indent') do
 
       # reset prev_token to last non-whitespace token on previous line
       prev_token = token.prev_token
-      while not prev_token.nil? and prev_token.type == :WHITESPACE
+      while not prev_token.nil? and (prev_token.type == :WHITESPACE or prev_token.type == :COMMENT)
         prev_token = prev_token.prev_token
       end
 

--- a/spec/puppet-lint/plugins/check_strict_indent_spec.rb
+++ b/spec/puppet-lint/plugins/check_strict_indent_spec.rb
@@ -41,6 +41,24 @@ describe 'strict_indent' do
     end
   end
 
+  context 'comment after resource title.' do
+    let(:code) {
+      <<-EOF.gsub(/^ {8}/, '')
+        class (
+        ) {
+          file {
+            'this': #comment
+              ensure  => 'present',
+          }
+        }
+      EOF
+    }
+
+    it 'should detect 0 problems' do
+      expect(problems).to have(0).problems
+    end
+  end
+
   context 'invalid array indent' do
     let(:code) {
       <<-EOF.gsub(/^ {8}/, '')


### PR DESCRIPTION
The logic to backtrack to the last non-whitespace on the previous line should also backtrack comments. Otherwise the following example would be generate a warning that the ensure line is indented to fare.

 ```
 class () {
   file {
     'this': #comment
       ensure  => 'present',
   }
 }
```