### PR TITLE
Add simplecov as a development dependency

### DIFF
--- a/puppet-lint-strict_indent-check.gemspec
+++ b/puppet-lint-strict_indent-check.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 require 'puppet-lint'
 
 PuppetLint::Plugins.load_spec_helper


### PR DESCRIPTION
It is a development dependency of puppet-lint.  Fixes:

    An error occurred while loading ./spec/puppet-lint/plugins/check_strict_indent_spec.rb.
    Failure/Error: PuppetLint::Plugins.load_spec_helper

    LoadError:
      cannot load such file -- simplecov

    # /home/romain/.bundle/gems/puppet-lint-2.3.6/spec/spec_helper.rb:1:in `require'
    # /home/romain/.bundle/gems/puppet-lint-2.3.6/spec/spec_helper.rb:1:in `<top (required)>'
    # /usr/home/romain/.bundle/gems/puppet-lint-2.3.6/lib/puppet-lint/plugins.rb:28:in `load'
    # /usr/home/romain/.bundle/gems/puppet-lint-2.3.6/lib/puppet-lint/plugins.rb:28:in `load_spec_helper'
    # ./spec/spec_helper.rb:3:in `<top (required)>'
    # ./spec/puppet-lint/plugins/check_strict_indent_spec.rb:1:in `require'
    # ./spec/puppet-lint/plugins/check_strict_indent_spec.rb:1:in `<top (required)>'