### PR TITLE
Fix issue with blank line at the beginning of a file.

### DIFF
--- a/lib/puppet-lint/plugins/check_strict_indent.rb
+++ b/lib/puppet-lint/plugins/check_strict_indent.rb
@@ -131,9 +131,9 @@ PuppetLint.new_check(:'strict_indent') do
       actual = 0
       if token.next_token.type == :INDENT
         actual = token.next_token.value.length
-      elsif token.prev_token.type == :HEREDOC
+      elsif !token.prev_token.nil? and token.prev_token.type == :HEREDOC
         actual = token.prev_token.value.split("\n").last.length
-      elsif token.prev_token.type == :HEREDOC_OPEN
+      elsif !token.prev_token.nil? and token.prev_token.type == :HEREDOC_OPEN
         actual = next_token.prev_token.value.split("\n").last.length
       else
         actual = 0

--- a/spec/puppet-lint/plugins/check_strict_indent_spec.rb
+++ b/spec/puppet-lint/plugins/check_strict_indent_spec.rb
@@ -77,4 +77,17 @@ describe 'strict_indent' do
       expect(problems).to have(1).problems
     end
   end
+
+  context 'blank line at beginning of file' do
+    let(:code) {
+      <<-EOF.gsub(/^ {8}/, '')
+
+        class () {}
+      EOF
+    }
+
+    it 'should detect 0 problems' do
+      expect(problems).to have(0).problems
+    end
+  end
 end


### PR DESCRIPTION
Fixes #16 

This resolves the issue where the linter would explode if the first line of a file was blank.
The issue was caused by not checking if the `token.prev_token` was `nil` or not while getting the indent.